### PR TITLE
isolate each model in its own module

### DIFF
--- a/.github/workflows/generate_website.yml
+++ b/.github/workflows/generate_website.yml
@@ -87,6 +87,7 @@ jobs:
         run: uv run ad.py run --model ${{ matrix.model }}
         env:
           ADTYPE_KEYS: ${{ needs.setup-keys.outputs.adtype_keys }}
+          ADTESTS_MODELS_TO_LOAD: ${{ matrix.model }}
 
       - name: Output matrix values
         id: output-matrix

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]

--- a/main.jl
+++ b/main.jl
@@ -57,62 +57,61 @@ definition file:
  - Once defined, the model is created using `model = model_name(...)`. The
    `model` on the left-hand side is mandatory.
 """
-function include_model(model_name::AbstractString)
-    module_contents = quote
-        using DynamicPPL: @model, to_submodel
-        using Distributions
-        using LinearAlgebra: I
-        using .Main: @register
-        include("models/" * $(model_name) * ".jl")
-        @register model
-    end
-    module_name = Symbol("ADTests_", model_name)
-    # Ideally, this would be a macro. However, defining a module in a macro is
-    # either incredibly difficult or impossible. See
-    # https://github.com/TuringLang/ADTests/issues/31
-    eval(Expr(:module, true, module_name, module_contents))
+macro include_model(model_name::AbstractString)
+    # in principle esc() shouldn't be needed, but see
+    # https://github.com/JuliaLang/julia/issues/55677
+    Expr(:toplevel, esc(:(
+        module $(gensym())
+            using DynamicPPL: @model, to_submodel
+            using Distributions
+            using LinearAlgebra: I
+            using .Main: @register
+            include("models/" * $(model_name) * ".jl")
+            @register model
+        end
+    )))
 end
 
-include_model("assume_beta")
-include_model("assume_dirichlet")
-include_model("assume_lkjcholu")
-include_model("assume_mvnormal")
-include_model("assume_normal")
-include_model("assume_submodel")
-include_model("assume_wishart")
-include_model("broadcast_macro")
-include_model("control_flow")
-include_model("demo_assume_dot_observe")
-include_model("demo_assume_dot_observe_literal")
-include_model("demo_assume_index_observe")
-include_model("demo_assume_matrix_observe_matrix_index")
-include_model("demo_assume_multivariate_observe")
-include_model("demo_assume_multivariate_observe_literal")
-include_model("demo_assume_observe_literal")
-include_model("demo_assume_submodel_observe_index_literal")
-include_model("demo_dot_assume_observe")
-include_model("demo_dot_assume_observe_index")
-include_model("demo_dot_assume_observe_index_literal")
-include_model("demo_dot_assume_observe_matrix_index")
-include_model("demo_dot_assume_observe_submodel")
-include_model("dot_assume")
-include_model("dot_observe")
-include_model("dynamic_constraint")
-include_model("multiple_constraints_same_var")
-include_model("multithreaded")
-include_model("n010")
-include_model("n050")
-include_model("n100")
-include_model("n500")
-include_model("observe_bernoulli")
-include_model("observe_categorical")
-include_model("observe_index")
-include_model("observe_literal")
-include_model("observe_multivariate")
-include_model("observe_submodel")
-include_model("pdb_eight_schools_centered")
-include_model("pdb_eight_schools_noncentered")
-include_model("von_mises")
+@include_model "assume_beta"
+@include_model "assume_dirichlet"
+@include_model "assume_lkjcholu"
+@include_model "assume_mvnormal"
+@include_model "assume_normal"
+@include_model "assume_submodel"
+@include_model "assume_wishart"
+@include_model "broadcast_macro"
+@include_model "control_flow"
+@include_model "demo_assume_dot_observe"
+@include_model "demo_assume_dot_observe_literal"
+@include_model "demo_assume_index_observe"
+@include_model "demo_assume_matrix_observe_matrix_index"
+@include_model "demo_assume_multivariate_observe"
+@include_model "demo_assume_multivariate_observe_literal"
+@include_model "demo_assume_observe_literal"
+@include_model "demo_assume_submodel_observe_index_literal"
+@include_model "demo_dot_assume_observe"
+@include_model "demo_dot_assume_observe_index"
+@include_model "demo_dot_assume_observe_index_literal"
+@include_model "demo_dot_assume_observe_matrix_index"
+@include_model "demo_dot_assume_observe_submodel"
+@include_model "dot_assume"
+@include_model "dot_observe"
+@include_model "dynamic_constraint"
+@include_model "multiple_constraints_same_var"
+@include_model "multithreaded"
+@include_model "n010"
+@include_model "n050"
+@include_model "n100"
+@include_model "n500"
+@include_model "observe_bernoulli"
+@include_model "observe_categorical"
+@include_model "observe_index"
+@include_model "observe_literal"
+@include_model "observe_multivariate"
+@include_model "observe_submodel"
+@include_model "pdb_eight_schools_centered"
+@include_model "pdb_eight_schools_noncentered"
+@include_model "von_mises"
 
 # The entry point to this script itself begins here
 if ARGS == ["--list-model-keys"]

--- a/main.jl
+++ b/main.jl
@@ -62,10 +62,8 @@ macro include_model(model_name::AbstractString)
     # https://github.com/JuliaLang/julia/issues/55677
     Expr(:toplevel, esc(:(
         module $(gensym())
-            using DynamicPPL: @model, to_submodel
-            using Distributions
-            using LinearAlgebra: I
             using .Main: @register
+            using Turing
             include("models/" * $(model_name) * ".jl")
             @register model
         end

--- a/models/assume_beta.jl
+++ b/models/assume_beta.jl
@@ -2,4 +2,4 @@
     a ~ Beta(2, 2)
 end
 
-@register assume_beta()
+model = assume_beta()

--- a/models/assume_dirichlet.jl
+++ b/models/assume_dirichlet.jl
@@ -2,4 +2,4 @@
     a ~ Dirichlet([1.0, 5.0])
 end
 
-@register assume_dirichlet()
+model = assume_dirichlet()

--- a/models/assume_lkjcholu.jl
+++ b/models/assume_lkjcholu.jl
@@ -2,4 +2,4 @@
     a ~ LKJCholesky(5, 1.0, 'U')
 end
 
-@register assume_lkjcholu()
+model = assume_lkjcholu()

--- a/models/assume_mvnormal.jl
+++ b/models/assume_mvnormal.jl
@@ -2,4 +2,4 @@
     a ~ MvNormal([0.0, 0.0], [1.0 0.5; 0.5 1.0])
 end
 
-@register assume_mvnormal()
+model = assume_mvnormal()

--- a/models/assume_normal.jl
+++ b/models/assume_normal.jl
@@ -2,4 +2,4 @@
     a ~ Normal()
 end
 
-@register assume_normal()
+model = assume_normal()

--- a/models/assume_submodel.jl
+++ b/models/assume_submodel.jl
@@ -6,4 +6,4 @@ end
     x ~ Normal(a)
 end
 
-@register assume_submodel()
+model = assume_submodel()

--- a/models/assume_wishart.jl
+++ b/models/assume_wishart.jl
@@ -2,4 +2,4 @@
     a ~ Wishart(7, [1.0 0.5; 0.5 1.0])
 end
 
-@register assume_wishart()
+model = assume_wishart()

--- a/models/broadcast_macro.jl
+++ b/models/broadcast_macro.jl
@@ -7,4 +7,4 @@
     @. x ~ Normal(a, $(sqrt(b)))
 end
 
-@register broadcast_macro()
+model = broadcast_macro()

--- a/models/control_flow.jl
+++ b/models/control_flow.jl
@@ -18,4 +18,4 @@ evaluated at a value of `a < 0`. See `main.jl` for more information.
     end
 end
 
-@register control_flow()
+model = control_flow()

--- a/models/demo_assume_dot_observe.jl
+++ b/models/demo_assume_dot_observe.jl
@@ -5,4 +5,4 @@
     x .~ Normal(m, sqrt(s))
 end
 
-@register demo_assume_dot_observe()
+model = demo_assume_dot_observe()

--- a/models/demo_assume_dot_observe_literal.jl
+++ b/models/demo_assume_dot_observe_literal.jl
@@ -5,4 +5,4 @@
     [1.5, 2.0] .~ Normal(m, sqrt(s))
 end
 
-@register demo_assume_dot_observe_literal()
+model = demo_assume_dot_observe_literal()

--- a/models/demo_assume_index_observe.jl
+++ b/models/demo_assume_index_observe.jl
@@ -14,4 +14,4 @@
     x ~ MvNormal(m, Diagonal(s))
 end
 
-@register demo_assume_index_observe()
+model = demo_assume_index_observe()

--- a/models/demo_assume_index_observe.jl
+++ b/models/demo_assume_index_observe.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_assume_index_observe(
     x = [1.5, 2.0],
     ::Type{TV} = Vector{Float64},

--- a/models/demo_assume_matrix_observe_matrix_index.jl
+++ b/models/demo_assume_matrix_observe_matrix_index.jl
@@ -11,4 +11,4 @@
     x[:, 1] ~ MvNormal(m, Diagonal(s_vec))
 end
 
-@register demo_assume_matrix_observe_matrix_index()
+model = demo_assume_matrix_observe_matrix_index()

--- a/models/demo_assume_matrix_observe_matrix_index.jl
+++ b/models/demo_assume_matrix_observe_matrix_index.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_assume_matrix_observe_matrix_index(
     x = transpose([1.5 2.0;]),
     ::Type{TV} = Array{Float64},
@@ -7,7 +9,6 @@
     s ~ reshape(product_distribution(fill(InverseGamma(2, 3), n)), d, 2)
     s_vec = vec(s)
     m ~ MvNormal(zeros(n), Diagonal(s_vec))
-
     x[:, 1] ~ MvNormal(m, Diagonal(s_vec))
 end
 

--- a/models/demo_assume_multivariate_observe.jl
+++ b/models/demo_assume_multivariate_observe.jl
@@ -1,7 +1,10 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_assume_multivariate_observe(x = [1.5, 2.0])
     # Multivariate `assume` and `observe`
     s ~ product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)])
     m ~ MvNormal(zero(x), Diagonal(s))
     x ~ MvNormal(m, Diagonal(s))
 end
+
 model = demo_assume_multivariate_observe()

--- a/models/demo_assume_multivariate_observe.jl
+++ b/models/demo_assume_multivariate_observe.jl
@@ -4,4 +4,4 @@
     m ~ MvNormal(zero(x), Diagonal(s))
     x ~ MvNormal(m, Diagonal(s))
 end
-@register demo_assume_multivariate_observe()
+model = demo_assume_multivariate_observe()

--- a/models/demo_assume_multivariate_observe_literal.jl
+++ b/models/demo_assume_multivariate_observe_literal.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_assume_multivariate_observe_literal()
     # multivariate `assume` and literal `observe`
     s ~ product_distribution([InverseGamma(2, 3), InverseGamma(2, 3)])

--- a/models/demo_assume_multivariate_observe_literal.jl
+++ b/models/demo_assume_multivariate_observe_literal.jl
@@ -5,4 +5,4 @@
     [1.5, 2.0] ~ MvNormal(m, Diagonal(s))
 end
 
-@register demo_assume_multivariate_observe_literal()
+model = demo_assume_multivariate_observe_literal()

--- a/models/demo_assume_observe_literal.jl
+++ b/models/demo_assume_observe_literal.jl
@@ -6,4 +6,4 @@
     2.0 ~ Normal(m, sqrt(s))
 end
 
-@register demo_assume_observe_literal()
+model = demo_assume_observe_literal()

--- a/models/demo_assume_submodel_observe_index_literal.jl
+++ b/models/demo_assume_submodel_observe_index_literal.jl
@@ -14,4 +14,4 @@ end
     2.0 ~ Normal(m[2], sqrt(s[2]))
 end
 
-@register demo_assume_submodel_observe_index_literal()
+model = demo_assume_submodel_observe_index_literal()

--- a/models/demo_dot_assume_observe.jl
+++ b/models/demo_dot_assume_observe.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_dot_assume_observe(
     x = [1.5, 2.0],
     ::Type{TV} = Vector{Float64},

--- a/models/demo_dot_assume_observe.jl
+++ b/models/demo_dot_assume_observe.jl
@@ -10,4 +10,4 @@
     x ~ MvNormal(m, Diagonal(s))
 end
 
-@register demo_dot_assume_observe()
+model = demo_dot_assume_observe()

--- a/models/demo_dot_assume_observe_index.jl
+++ b/models/demo_dot_assume_observe_index.jl
@@ -12,4 +12,4 @@
     end
 end
 
-@register demo_dot_assume_observe_index()
+model = demo_dot_assume_observe_index()

--- a/models/demo_dot_assume_observe_index_literal.jl
+++ b/models/demo_dot_assume_observe_index_literal.jl
@@ -11,4 +11,4 @@
     2.0 ~ Normal(m[2], sqrt(s[2]))
 end
 
-@register demo_dot_assume_observe_index_literal()
+model = demo_dot_assume_observe_index_literal()

--- a/models/demo_dot_assume_observe_matrix_index.jl
+++ b/models/demo_dot_assume_observe_matrix_index.jl
@@ -9,4 +9,4 @@
     x[:, 1] ~ MvNormal(m, Diagonal(s))
 end
 
-@register demo_dot_assume_observe_matrix_index()
+model = demo_dot_assume_observe_matrix_index()

--- a/models/demo_dot_assume_observe_matrix_index.jl
+++ b/models/demo_dot_assume_observe_matrix_index.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function demo_dot_assume_observe_matrix_index(
     x = transpose([1.5 2.0;]),
     ::Type{TV} = Vector{Float64},

--- a/models/demo_dot_assume_observe_submodel.jl
+++ b/models/demo_dot_assume_observe_submodel.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: Diagonal
+
 @model function _likelihood_multivariate_observe(s, m, x)
     return x ~ MvNormal(m, Diagonal(s))
 end

--- a/models/demo_dot_assume_observe_submodel.jl
+++ b/models/demo_dot_assume_observe_submodel.jl
@@ -17,4 +17,4 @@ end
     _ignore ~ to_submodel(_likelihood_multivariate_observe(s, m, x))
 end
 
-@register demo_dot_assume_observe_submodel()
+model = demo_dot_assume_observe_submodel()

--- a/models/dot_assume.jl
+++ b/models/dot_assume.jl
@@ -3,4 +3,4 @@
     a .~ Normal()
 end
 
-@register dot_assume()
+model = dot_assume()

--- a/models/dot_observe.jl
+++ b/models/dot_observe.jl
@@ -3,4 +3,4 @@
     x .~ Normal(a)
 end
 
-@register dot_observe()
+model = dot_observe()

--- a/models/dynamic_constraint.jl
+++ b/models/dynamic_constraint.jl
@@ -3,4 +3,4 @@
     b ~ truncated(Normal(); lower = a)
 end
 
-@register dynamic_constraint()
+model = dynamic_constraint()

--- a/models/multiple_constraints_same_var.jl
+++ b/models/multiple_constraints_same_var.jl
@@ -6,4 +6,4 @@
     x[4:5] ~ Dirichlet([1.0, 2.0])
 end
 
-@register multiple_constraints_same_var()
+model = multiple_constraints_same_var()

--- a/models/multithreaded.jl
+++ b/models/multithreaded.jl
@@ -11,4 +11,4 @@ statements. See `main.jl` for more information.
     end
 end
 
-@register multithreaded([1.5, 2.0, 2.5, 1.5, 2.0, 2.5])
+model = multithreaded([1.5, 2.0, 2.5, 1.5, 2.0, 2.5])

--- a/models/n010.jl
+++ b/models/n010.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register n010()
+model = n010()

--- a/models/n050.jl
+++ b/models/n050.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register n050()
+model = n050()

--- a/models/n100.jl
+++ b/models/n100.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register n100()
+model = n100()

--- a/models/n500.jl
+++ b/models/n500.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register n500()
+model = n500()

--- a/models/observe_bernoulli.jl
+++ b/models/observe_bernoulli.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register observe_bernoulli()
+model = observe_bernoulli()

--- a/models/observe_categorical.jl
+++ b/models/observe_categorical.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register observe_categorical()
+model = observe_categorical()

--- a/models/observe_index.jl
+++ b/models/observe_index.jl
@@ -5,4 +5,4 @@
     end
 end
 
-@register observe_index()
+model = observe_index()

--- a/models/observe_literal.jl
+++ b/models/observe_literal.jl
@@ -3,4 +3,4 @@
     1.5 ~ Normal(a)
 end
 
-@register observe_literal()
+model = observe_literal()

--- a/models/observe_multivariate.jl
+++ b/models/observe_multivariate.jl
@@ -7,4 +7,4 @@
     x ~ MvNormal(a, I)
 end
 
-@register observe_multivariate()
+model = observe_multivariate()

--- a/models/observe_submodel.jl
+++ b/models/observe_submodel.jl
@@ -6,4 +6,4 @@ end
     _ignore ~ to_submodel(inner2(x, a))
 end
 
-@register observe_submodel()
+model = observe_submodel()

--- a/models/pdb_eight_schools_centered.jl
+++ b/models/pdb_eight_schools_centered.jl
@@ -12,4 +12,4 @@ sigma = [15, 10, 16, 11, 9, 11, 10, 18]
     end
 end
 
-@register pdb_eight_schools_centered(J, y, sigma)
+model = pdb_eight_schools_centered(J, y, sigma)

--- a/models/pdb_eight_schools_noncentered.jl
+++ b/models/pdb_eight_schools_noncentered.jl
@@ -13,4 +13,4 @@ sigma = [15, 10, 16, 11, 9, 11, 10, 18]
     end
 end
 
-@register pdb_eight_schools_noncentered(J, y, sigma)
+model = pdb_eight_schools_noncentered(J, y, sigma)

--- a/models/von_mises.jl
+++ b/models/von_mises.jl
@@ -3,4 +3,4 @@
     x ~ VonMises(0, a)
 end
 
-@register von_mises(0.4)
+model = von_mises(0.4)


### PR DESCRIPTION
Closes #31

Since we changed `using LinearAlgebra` to `using LinearAlgebra: I`, some things are likely to fail. After #23 is merged we could just switch this to `using Turing` which would match the current version of Turing.